### PR TITLE
fix: correct BCP-47 link from bcp14 to bcp47

### DIFF
--- a/FSD/CEG/00_conformance.md
+++ b/FSD/CEG/00_conformance.md
@@ -79,7 +79,7 @@ The following documents are normatively cited; implementations MUST conform to t
 | [RFC-8785] | [RFC 8785](https://www.rfc-editor.org/rfc/rfc8785) — JSON Canonicalization Scheme (JCS); used where this spec serializes JSON for signing |
 | [RFC-9162] | [RFC 9162](https://www.rfc-editor.org/rfc/rfc9162) — Certificate Transparency v2.0 (CT-bis); MUST be used for new transparency-log integrations; older 6962 instances continue to interoperate |
 | [ISO-639-1] | [ISO 639-1:2002](https://www.iso.org/standard/22109.html) — Codes for the representation of names of languages, two-letter |
-| [BCP-47] | [BCP 47](https://www.rfc-editor.org/info/bcp14) ([RFC 5646](https://www.rfc-editor.org/rfc/rfc5646)) — Tags for identifying languages; for locale strings richer than ISO 639-1 alone |
+| [BCP-47] | [BCP 47](https://www.rfc-editor.org/info/bcp47) ([RFC 5646](https://www.rfc-editor.org/rfc/rfc5646)) — Tags for identifying languages; for locale strings richer than ISO 639-1 alone |
 | [RFC-9420] | [RFC 9420](https://www.rfc-editor.org/rfc/rfc9420) — Messaging Layer Security (MLS); the streaming epoch-key rekey ([§10.5.3](10_endpoints.md)) conforms to MLS TreeKEM |
 | [SFrame] | [draft-ietf-sframe](https://datatracker.ietf.org/wg/sframe/about/) — Secure Frames; the per-frame AEAD chunk seal ([§10.5.2](10_endpoints.md)) conforms to the SFrame model |
 | [FIPS-203] | [FIPS 203](https://csrc.nist.gov/pubs/fips/203/final) — ML-KEM (Module-Lattice KEM); the post-quantum half of the hybrid KEM (ML-KEM-768) |


### PR DESCRIPTION
## Fix

Correct the BCP-47 row URL in the Normative References table from `bcp14` to `bcp47` in `FSD/CEG/00_conformance.md`.

**Before:** `[BCP 47](https://www.rfc-editor.org/info/bcp14)`
**After:** `[BCP 47](https://www.rfc-editor.org/info/bcp47)`

The BCP-47 row correctly displays 'BCP 47' but was linking to the bcp14 RFC (requirement keywords) instead of bcp47 (language tags, RFC 5646).

Closes #101.